### PR TITLE
Support retrieving entity details from query service

### DIFF
--- a/frontend/src/services/FakeDataQueryService.ts
+++ b/frontend/src/services/FakeDataQueryService.ts
@@ -2,7 +2,9 @@ import { injectable } from 'inversify';
 import 'reflect-metadata';
 import { LimitQuery } from '../shared/queries/LimitQuery';
 import { QueryResult } from '../shared/queries/QueryResult';
+import { Node } from '../shared/entities/Node';
 import { NodeDescriptor } from '../shared/entities/NodeDescriptor';
+import { Edge } from '../shared/entities/Edge';
 import { EdgeDescriptor } from '../shared/entities/EdgeDescriptor';
 import delay from '../utils/delay';
 import QueryService from './QueryService';
@@ -54,5 +56,19 @@ export default class FakeDataQueryService extends QueryService {
     }
 
     return { nodes, edges };
+  }
+
+  public getEdgesById(
+    idsOrDescriptors: number[] | EdgeDescriptor[],
+    cancellation?: CancellationToken
+  ): Promise<(Edge | null)[]> {
+    return Promise.resolve<(Edge | null)[]>(idsOrDescriptors.map(() => null));
+  }
+
+  public getNodesById(
+    idsOrDescriptors: number[] | NodeDescriptor[],
+    cancellation?: CancellationToken
+  ): Promise<(Node | null)[]> {
+    return Promise.resolve<(Node | null)[]>(idsOrDescriptors.map(() => null));
   }
 }

--- a/frontend/src/services/FakeDataQueryService.ts
+++ b/frontend/src/services/FakeDataQueryService.ts
@@ -61,14 +61,14 @@ export default class FakeDataQueryService extends QueryService {
   public getEdgesById(
     idsOrDescriptors: number[] | EdgeDescriptor[],
     cancellation?: CancellationToken
-  ): Promise<(Edge | null)[]> {
-    return Promise.resolve<(Edge | null)[]>(idsOrDescriptors.map(() => null));
+  ): Promise<Edge[]> {
+    return Promise.resolve<Edge[]>([]);
   }
 
   public getNodesById(
     idsOrDescriptors: number[] | NodeDescriptor[],
     cancellation?: CancellationToken
-  ): Promise<(Node | null)[]> {
-    return Promise.resolve<(Node | null)[]>(idsOrDescriptors.map(() => null));
+  ): Promise<Node[]> {
+    return Promise.resolve<Node[]>([]);
   }
 }

--- a/frontend/src/services/QueryService.ts
+++ b/frontend/src/services/QueryService.ts
@@ -52,12 +52,12 @@ export default abstract class QueryService {
   public abstract getEdgesById(
     ids: number[],
     cancellation?: CancellationToken
-  ): Promise<(Edge | null)[]>;
+  ): Promise<Edge[]>;
 
   public abstract getEdgesById(
     descriptors: EdgeDescriptor[],
     cancellation?: CancellationToken
-  ): Promise<(Edge | null)[]>;
+  ): Promise<Edge[]>;
 
   public getNodeById(
     id: number,
@@ -87,10 +87,10 @@ export default abstract class QueryService {
   public abstract getNodesById(
     ids: number[],
     cancellation?: CancellationToken
-  ): Promise<(Node | null)[]>;
+  ): Promise<Node[]>;
 
   public abstract getNodesById(
     descriptors: NodeDescriptor[],
     cancellation?: CancellationToken
-  ): Promise<(Node | null)[]>;
+  ): Promise<Node[]>;
 }

--- a/frontend/src/services/QueryService.ts
+++ b/frontend/src/services/QueryService.ts
@@ -1,5 +1,9 @@
 import { injectable } from 'inversify';
 import 'reflect-metadata';
+import { Edge } from '../shared/entities/Edge';
+import { EdgeDescriptor } from '../shared/entities/EdgeDescriptor';
+import { Node } from '../shared/entities/Node';
+import { NodeDescriptor } from '../shared/entities/NodeDescriptor';
 import { LimitQuery } from '../shared/queries/LimitQuery';
 import { QueryResult } from '../shared/queries/QueryResult';
 import { CancellationToken } from '../utils/CancellationToken';
@@ -19,4 +23,74 @@ export default abstract class QueryService {
     query?: LimitQuery,
     cancellation?: CancellationToken
   ): Promise<QueryResult>;
+
+  public getEdgeById(
+    id: number,
+    cancellation?: CancellationToken
+  ): Promise<Edge | null>;
+
+  public getEdgeById(
+    descriptor: EdgeDescriptor,
+    cancellation?: CancellationToken
+  ): Promise<Edge | null>;
+
+  public async getEdgeById(
+    idOrDescriptor: number | EdgeDescriptor,
+    cancellation?: CancellationToken
+  ): Promise<Edge | null> {
+    const id =
+      typeof idOrDescriptor === 'number' ? idOrDescriptor : idOrDescriptor.id;
+    const resultArray = await this.getEdgesById([id], cancellation);
+
+    if (resultArray.length === 0) {
+      return null;
+    }
+
+    return resultArray[0];
+  }
+
+  public abstract getEdgesById(
+    ids: number[],
+    cancellation?: CancellationToken
+  ): Promise<(Edge | null)[]>;
+
+  public abstract getEdgesById(
+    descriptors: EdgeDescriptor[],
+    cancellation?: CancellationToken
+  ): Promise<(Edge | null)[]>;
+
+  public getNodeById(
+    id: number,
+    cancellation?: CancellationToken
+  ): Promise<Node | null>;
+
+  public getNodeById(
+    descriptor: NodeDescriptor,
+    cancellation?: CancellationToken
+  ): Promise<Node | null>;
+
+  public async getNodeById(
+    idOrDescriptor: number | NodeDescriptor,
+    cancellation?: CancellationToken
+  ): Promise<Node | null> {
+    const id =
+      typeof idOrDescriptor === 'number' ? idOrDescriptor : idOrDescriptor.id;
+    const resultArray = await this.getNodesById([id], cancellation);
+
+    if (resultArray.length === 0) {
+      return null;
+    }
+
+    return resultArray[0];
+  }
+
+  public abstract getNodesById(
+    ids: number[],
+    cancellation?: CancellationToken
+  ): Promise<(Node | null)[]>;
+
+  public abstract getNodesById(
+    descriptors: NodeDescriptor[],
+    cancellation?: CancellationToken
+  ): Promise<(Node | null)[]>;
 }

--- a/frontend/src/services/QueryServiceImpl.ts
+++ b/frontend/src/services/QueryServiceImpl.ts
@@ -45,8 +45,8 @@ export default class QueryServiceImpl extends QueryService {
   public getEdgesById(
     idsOrDescriptors: number[] | EdgeDescriptor[],
     cancellation?: CancellationToken
-  ): Promise<(Edge | null)[]> {
-    return this.http.get<(Edge | null)[]>(
+  ): Promise<Edge[]> {
+    return this.http.get<Edge[]>(
       '/getEdgesById',
       buildDetailsRequest(idsOrDescriptors),
       cancellation
@@ -56,8 +56,8 @@ export default class QueryServiceImpl extends QueryService {
   public getNodesById(
     idsOrDescriptors: number[] | NodeDescriptor[],
     cancellation?: CancellationToken
-  ): Promise<(Node | null)[]> {
-    return this.http.get<(Node | null)[]>(
+  ): Promise<Node[]> {
+    return this.http.get<Node[]>(
       '/getNodesById',
       buildDetailsRequest(idsOrDescriptors),
       cancellation


### PR DESCRIPTION
This PR adds the support to retrieve node/edge details from the query service by requesting them from the backend that was implemented by #61.  
This does not include caching entity details in the frontend, as described by #62.