### PR TITLE
Filter include all nodes

### DIFF
--- a/backend/src/filter/FilterConditionBuilder.ts
+++ b/backend/src/filter/FilterConditionBuilder.ts
@@ -38,7 +38,7 @@ export default class FilterConditionBuilder extends FilterConditionVisitor {
     if (this.entity === 'node') {
       this.resultCondition = `$${paramName} in labels(${this.name})`;
     } else {
-      this.resultCondition = `$${paramName} == type(${this.name})`;
+      this.resultCondition = `$${paramName} = type(${this.name})`;
     }
 
     this.queryParams[paramName] = type;
@@ -56,7 +56,7 @@ export default class FilterConditionBuilder extends FilterConditionVisitor {
       `${property}_value`
     );
 
-    this.resultCondition = `${this.name}.$${propertyParamName} == $${valueParamName}`;
+    this.resultCondition = `${this.name}.$${propertyParamName} = $${valueParamName}`;
 
     this.queryParams[propertyParamName] = property;
     this.queryParams[valueParamName] = value;

--- a/backend/src/filter/filter.service.ts
+++ b/backend/src/filter/filter.service.ts
@@ -43,7 +43,7 @@ export class FilterService implements FilterServiceBase {
 
     const queryResult = { nodes, edges };
 
-    return consolidateQueryResult(queryResult);
+    return consolidateQueryResult(queryResult, true);
   }
 
   private async getNodes(

--- a/backend/src/utils/consolidateQueryResult.ts
+++ b/backend/src/utils/consolidateQueryResult.ts
@@ -48,6 +48,7 @@ function deduplicateEntities<T extends HasId>(
  * Consolidates the specified query result, such that it contains only edges
  * that's to and from nodes are included in the query-result.
  * @param queryResult The query-result to filter
+ * @param includeSubsidiary A boolean value that indicated whether nodes that are not part of the result but references by edges that are part of the results shall be added or the referencing edges deleted.
  */
 export default function consolidateQueryResult(
   queryResult: QueryResult,

--- a/backend/tests/e2e/filter/filter.service.e2e.spec.ts
+++ b/backend/tests/e2e/filter/filter.service.e2e.spec.ts
@@ -7,6 +7,11 @@ import {
   getEdgeTypeFilterModelResult,
   getNodeTypeFilterModelResult,
 } from '../../fixtures/filter/FilterQueryResults';
+import {
+  FilterQuery,
+  OfTypeCondition,
+  QueryResult,
+} from '../../../src/shared/queries';
 
 /*
 Tests filter.service.ts
@@ -33,6 +38,29 @@ describe('FilterService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('Method query', () => {
+    it('returns all nodes including subsidiary ones', async () => {
+      // Arrange
+      const query: FilterQuery = {
+        filters: {
+          nodes: OfTypeCondition('Movie'),
+          edges: OfTypeCondition('DIRECTED'),
+        },
+      };
+
+      const expectedQueryResult: QueryResult = {
+        nodes: [{ id: 0 }, { id: 3, subsidiary: true }],
+        edges: [{ id: 2, from: 3, to: 0 }],
+      };
+
+      // Act
+      const result = await service.query(query);
+
+      // Assert
+      expect(result).toEqual(expectedQueryResult);
+    });
   });
 
   describe('Method getNodeTypeFilterModel', () => {

--- a/backend/tests/unit/utils/consolidateQueryResult.spec.ts
+++ b/backend/tests/unit/utils/consolidateQueryResult.spec.ts
@@ -1,0 +1,95 @@
+import consolidateQueryResult from '../../../src/utils/consolidateQueryResult';
+
+describe('consolidateQueryResult', () => {
+  it('deduplicates nodes', async () => {
+    // Arrange
+    const queryResult = {
+      nodes: [{ id: 1 }, { id: 2 }, { id: 1 }],
+      edges: [],
+    };
+
+    const expectedQueryResult = {
+      nodes: [{ id: 1 }, { id: 2 }],
+      edges: [],
+    };
+
+    // Act
+    const consolidatedQueryResult = consolidateQueryResult(queryResult);
+
+    // Assert
+    expect(consolidatedQueryResult).toStrictEqual(expectedQueryResult);
+  });
+
+  it('deduplicates edges', async () => {
+    // Arrange
+    const queryResult = {
+      nodes: [{ id: 0 }],
+      edges: [
+        { id: 1, from: 0, to: 0 },
+        { id: 2, from: 0, to: 0 },
+        { id: 1, from: 0, to: 0 },
+      ],
+    };
+
+    const expectedQueryResult = {
+      nodes: [{ id: 0 }],
+      edges: [
+        { id: 1, from: 0, to: 0 },
+        { id: 2, from: 0, to: 0 },
+      ],
+    };
+
+    // Act
+    const consolidatedQueryResult = consolidateQueryResult(queryResult);
+
+    // Assert
+    expect(consolidatedQueryResult).toStrictEqual(expectedQueryResult);
+  });
+
+  it('removed edges that reference non included nodes', async () => {
+    // Arrange
+    const queryResult = {
+      nodes: [{ id: 0 }],
+      edges: [
+        { id: 1, from: 0, to: 0 },
+        { id: 2, from: 0, to: 1 },
+      ],
+    };
+
+    const expectedQueryResult = {
+      nodes: [{ id: 0 }],
+      edges: [{ id: 1, from: 0, to: 0 }],
+    };
+
+    // Act
+    const consolidatedQueryResult = consolidateQueryResult(queryResult);
+
+    // Assert
+    expect(consolidatedQueryResult).toStrictEqual(expectedQueryResult);
+  });
+
+  it('adds subsidiary nodes that are non included but referenced by included edges', async () => {
+    // Arrange
+    const queryResult = {
+      nodes: [{ id: 0 }],
+      edges: [
+        { id: 1, from: 0, to: 0 },
+        { id: 2, from: 0, to: 1 },
+      ],
+    };
+
+    const expectedQueryResult = {
+      nodes: [{ id: 0 }, { id: 1, subsidiary: true }],
+      edges: [
+        { id: 1, from: 0, to: 0 },
+        { id: 2, from: 0, to: 1 },
+      ],
+    };
+
+    // Act
+    const consolidatedQueryResult = consolidateQueryResult(queryResult, true);
+
+    // Assert
+    expect(consolidatedQueryResult).toStrictEqual(expectedQueryResult);
+  });
+});

--- a/shared/src/queries/NodeResultDescriptor.ts
+++ b/shared/src/queries/NodeResultDescriptor.ts
@@ -1,0 +1,8 @@
+import { NodeDescriptor } from '../entities/NodeDescriptor';
+
+export default interface NodeResultDescriptor extends NodeDescriptor {
+  /**
+   * A boolean that specifies whether the node is part of the result only to support edges that are part of the result that reference the node.
+   */
+  subsidiary?: boolean;
+}

--- a/shared/src/queries/NodeResultDescriptor.ts
+++ b/shared/src/queries/NodeResultDescriptor.ts
@@ -1,5 +1,8 @@
 import { NodeDescriptor } from '../entities/NodeDescriptor';
 
+/**
+ * NodeDescriptor with additional information about the node in context of a query result.
+ */
 export default interface NodeResultDescriptor extends NodeDescriptor {
   /**
    * A boolean that specifies whether the node is part of the result only to support edges that are part of the result that reference the node.

--- a/shared/src/queries/QueryResult.ts
+++ b/shared/src/queries/QueryResult.ts
@@ -1,5 +1,5 @@
 import { EdgeDescriptor } from '../entities/EdgeDescriptor';
-import { NodeDescriptor } from '../entities/NodeDescriptor';
+import NodeResultDescriptor from './NodeResultDescriptor';
 
 /**
  * Generic Result of an API Query.
@@ -10,7 +10,7 @@ export default interface QueryResult {
   /**
    * NodeDescriptors (array of node-ids) as result of the Query
    */
-  nodes: NodeDescriptor[];
+  nodes: NodeResultDescriptor[];
 
   /**
    * EdgeDescriptors (array of node-ids, from-ids and edge-ids) as result of the Query

--- a/shared/src/queries/index.ts
+++ b/shared/src/queries/index.ts
@@ -5,6 +5,7 @@ import FilterQuery, {
   MatchAllCondition,
   MatchAnyCondition,
 } from './FilterQuery';
+import NodeResultDescriptor from './NodeResultDescriptor';
 import QueryBase from './QueryBase';
 import QueryResult from './QueryResult';
 
@@ -15,4 +16,10 @@ export {
   MatchAnyCondition,
 };
 
-export type { FilterQuery, FilterCondition, QueryBase, QueryResult };
+export type {
+  FilterQuery,
+  FilterCondition,
+  NodeResultDescriptor,
+  QueryBase,
+  QueryResult,
+};


### PR DESCRIPTION
This PR includes information in the query result whether a node is part of the result due to the query matching or due to the query result containing an edge that references the node (subsidiary node).  This closes #153 
The PR also fixes a bug in the query condition builder.