### PR TITLE
Request manager

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,6 @@
     "clsx": "^1.1.1",
     "inversify": "^5.1.1",
     "react": "^17.0.2",
-    "react-async": "^10.0.1",
     "react-dom": "^17.0.2",
     "react-graph-vis": "^1.0.7",
     "react-router-dom": "^5.2.0",

--- a/frontend/src/errors/ErrorComponent.tsx
+++ b/frontend/src/errors/ErrorComponent.tsx
@@ -61,14 +61,14 @@ function ErrorComponent(props: ErrorComponentProps): JSX.Element {
   const { jsError } = props;
   const classes = useStyles();
 
-  // If a JS Error occured
+  // If a JS Error occurred
   if (jsError !== undefined) {
     const { imgSrc } = ErrorComponentData[ErrorType.GenericError];
     return (
       <Box className={classes.root}>
         <img src={imgSrc} className={classes.img} alt="" />
-        <h1>jsError.name</h1>
-        <p>jsError.message</p>
+        <h1>{jsError.name}</h1>
+        <p>{jsError.message}</p>
       </Box>
     );
   }

--- a/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
+++ b/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
@@ -93,8 +93,6 @@ function fetchDataFromService<TArgs extends unknown[], TData>(
   const [isLoading, setIsLoading] = useState(true);
   const [needsUpdate, setNeedsUpdate] = useState(false);
 
-  const lastUpdateRef = useRef<number | null>(null);
-
   useEffect(() => {
     let mounted = true;
 
@@ -106,7 +104,6 @@ function fetchDataFromService<TArgs extends unknown[], TData>(
     queryFn(...argsWithCancellation)
       .then((result) => {
         if (mounted) {
-          lastUpdateRef.current = Date.now();
           setData(result);
           setIsLoading(false);
           setNeedsUpdate(false);

--- a/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
+++ b/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
@@ -2,7 +2,7 @@ import Backdrop from '@material-ui/core/Backdrop';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Button from '@material-ui/core/Button';
 import CloseIcon from '@material-ui/icons/Close';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import {
   CancellationToken,
@@ -42,15 +42,15 @@ export interface FetchDataOptions<TArgs extends unknown[], TData> {
 }
 
 /**
- * Fetches data from service using {@link useAsync} with {@link promiseFn} executeQuery.
- * If the screen is still loading a {@link JSX.Element}, showing a loading screen, is returned.
- * if an error occurs a {@link JSX.Element}, showing an error screen, is returned.
- * If the data to be fetched is undefined a {@link JSX.Element}, showing an error message, is returned.
+ * Fetches data asynchronously and displays them with the specified render function.
+ * While the screen is loading a {@link JSX.Element}, showing a loading screen, is returned.
+ * When an error occurs a {@link JSX.Element}, showing an error screen, is returned.
+ * When the data to be fetched is undefined a {@link JSX.Element}, showing an error message, is returned.
  *
- * @param queryFn - the query the service executes
- * @param service - the service that executes the query
- * @param arg - optional, additional argument given to {@link useAsync}
- * @returns if one of the above cases occured, the corresponding {@link JSX.Element}, otherwise the data to be fetched
+ * @param queryFn - The function that executed the query.
+ * @param content - The function that renders the fetched data to a view described via a {@link JSX.Element}.
+ * @param args - Arguments that are passed to {@link queryFn} when it is invoked.
+ * @returns A view of the current state of the loading operation described via a {@link JSX.Element}.
  */
 function fetchDataFromService<TArgs extends unknown[], TData>(
   queryFn: QueryFunction<TArgs, TData>,
@@ -58,6 +58,17 @@ function fetchDataFromService<TArgs extends unknown[], TData>(
   ...args: TArgs
 ): JSX.Element;
 
+/**
+ * Fetches data asynchronously and displays them with the specified render function.
+ * While the screen is loading a {@link JSX.Element}, showing a loading screen, is returned.
+ * When an error occurs a {@link JSX.Element}, showing an error screen, is returned.
+ * When the data to be fetched is undefined a {@link JSX.Element}, showing an error message, is returned.
+ *
+ * @param options - An instance of {@link FetchDataOptions<TArgs, TData>} that contain the options of the query operation.
+ * @param content - The function that renders the fetched data to a view described via a {@link JSX.Element}.
+ * @param args - Arguments that are passed to {@link queryFn} when it is invoked.
+ * @returns A view of the current state of the loading operation described via a {@link JSX.Element}.
+ */
 function fetchDataFromService<TArgs extends unknown[], TData>(
   options: FetchDataOptions<TArgs, TData>,
   content: RenderFunction<TData>,

--- a/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
+++ b/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
@@ -30,14 +30,32 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
+/**
+ * A function that describe the render operation of fetched data to a view described via a {@link JSX.Element}.
+ * The function receives the fetched data. And optional a function that can be invoked to update the data.
+ */
 type RenderFunction<T> = (t: T, update: () => void) => JSX.Element;
 
+/**
+ * A function that asynchronously performs the query operation and returns a promise describing the asynchronous operation.
+ */
 type QueryFunction<TArgs extends unknown[], TResult> = (
   ...args: [...TArgs, CancellationToken]
 ) => Promise<TResult>;
 
+/**
+ * Describes the options of a data fetch operation.
+ */
 export interface FetchDataOptions<TArgs extends unknown[], TData> {
+  /**
+   * The query function used to fetch the data asynchronously.
+   */
   queryFn: QueryFunction<TArgs, TData>;
+
+  /**
+   * The default value of the data that will be rendered when no data is fetched (yet)
+   * OR undefined if no default data shall be rendered.
+   */
   defaultData?: TData;
 }
 

--- a/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
+++ b/frontend/src/visualization/shared-ops/fetchDataFromService.tsx
@@ -32,13 +32,12 @@ const useStyles = makeStyles((theme: Theme) =>
 
 type RenderFunction<T> = (t: T, update: () => void) => JSX.Element;
 
-type QueryFunction<
-  TArgs extends [...Array<unknown>, CancellationToken],
-  TResult
-> = (...args: TArgs) => Promise<TResult>;
+type QueryFunction<TArgs extends unknown[], TResult> = (
+  ...args: [...TArgs, CancellationToken]
+) => Promise<TResult>;
 
-export interface FetchDataOptions<TArgs extends Array<unknown>, TData> {
-  queryFn: QueryFunction<[...TArgs, CancellationToken], TData>;
+export interface FetchDataOptions<TArgs extends unknown[], TData> {
+  queryFn: QueryFunction<TArgs, TData>;
   defaultData?: TData;
 }
 
@@ -53,21 +52,21 @@ export interface FetchDataOptions<TArgs extends Array<unknown>, TData> {
  * @param arg - optional, additional argument given to {@link useAsync}
  * @returns if one of the above cases occured, the corresponding {@link JSX.Element}, otherwise the data to be fetched
  */
-function fetchDataFromService<TArgs extends Array<unknown>, TData>(
-  queryFn: QueryFunction<[...TArgs, CancellationToken], TData>,
+function fetchDataFromService<TArgs extends unknown[], TData>(
+  queryFn: QueryFunction<TArgs, TData>,
   content: RenderFunction<TData>,
   ...args: TArgs
 ): JSX.Element;
 
-function fetchDataFromService<TArgs extends Array<unknown>, TData>(
+function fetchDataFromService<TArgs extends unknown[], TData>(
   options: FetchDataOptions<TArgs, TData>,
   content: RenderFunction<TData>,
   ...args: TArgs
 ): JSX.Element;
 
-function fetchDataFromService<TArgs extends Array<unknown>, TData>(
+function fetchDataFromService<TArgs extends unknown[], TData>(
   queryFnOrOptions:
-    | QueryFunction<[...TArgs, CancellationToken], TData>
+    | QueryFunction<TArgs, TData>
     | FetchDataOptions<TArgs, TData>,
   content: RenderFunction<TData>,
   ...args: TArgs

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11978,11 +11978,6 @@ react-app-polyfill@^2.0.0:
     regenerator-runtime "^0.13.7"
     whatwg-fetch "^3.4.1"
 
-react-async@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/react-async/-/react-async-10.0.1.tgz#575c083f808303d2f6ca52d11ec7554dbdbd9fcd"
-  integrity sha512-ORUz5ca0B57QgBIzEZM5SuhJ6xFjkvEEs0gylLNlWf06vuVcLZsjIw3wx58jJkZG38p+0nUAxRgFW2b7mnVZzA==
-
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.4.tgz#a7ccb60257a1ca2e0efe7a83e38e6700d17aa37a"


### PR DESCRIPTION
This PR refactors the `fetchDataFromService`used in the graph view and removes the dependency to the `react-async` library. It also allows for updates of the data, therefore fixes #106.

There is still an issue open. When the graph view is reloaded due to the data changing, the sidebar is reloaded too, as the component gets re-rendered. This is tracked by #186 