### PR TITLE
Error boundary

### DIFF
--- a/frontend/src/errors/ErrorBoundary.tsx
+++ b/frontend/src/errors/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import ErrorComponent from './ErrorComponent';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | undefined;
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      error: undefined,
+      hasError: false,
+    };
+  }
+
+  public static getDerivedStateFromError(e: Error): State {
+    // Update state so the next render will show the error component.
+    return { error: e, hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // eslint-disable-next-line no-console -- should we log this instead?
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  public render(): ReactNode {
+    const { hasError, error } = this.state;
+    const { children } = this.props;
+    if (hasError) {
+      return <ErrorComponent jsError={error} />;
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/errors/ErrorBoundary.tsx
+++ b/frontend/src/errors/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react';
+import React, { ErrorInfo, ReactNode } from 'react';
 import ErrorComponent from './ErrorComponent';
 
 interface Props {

--- a/frontend/src/errors/ErrorBoundary.tsx
+++ b/frontend/src/errors/ErrorBoundary.tsx
@@ -6,22 +6,20 @@ interface Props {
 }
 
 interface State {
-  error: Error | undefined;
-  hasError: boolean;
+  error: Error | null;
 }
 
-class ErrorBoundary extends Component<Props, State> {
+class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      error: undefined,
-      hasError: false,
+      error: null,
     };
   }
 
-  public static getDerivedStateFromError(e: Error): State {
+  public static getDerivedStateFromError(error: Error): State {
     // Update state so the next render will show the error component.
-    return { error: e, hasError: true };
+    return { error };
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
@@ -30,12 +28,11 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   public render(): ReactNode {
-    const { hasError, error } = this.state;
+    const { error } = this.state;
     const { children } = this.props;
-    if (hasError) {
+    if (error) {
       return <ErrorComponent jsError={error} />;
     }
-
     return children;
   }
 }

--- a/frontend/src/errors/ErrorComponent.tsx
+++ b/frontend/src/errors/ErrorComponent.tsx
@@ -67,8 +67,8 @@ function ErrorComponent(props: ErrorComponentProps): JSX.Element {
     return (
       <Box className={classes.root}>
         <img src={imgSrc} className={classes.img} alt="" />
-        <h1>jsError.name</h1>
-        <p>jsError.message</p>
+        <h1>{jsError.name}</h1>
+        <p>{jsError.message}</p>
       </Box>
     );
   }

--- a/frontend/src/routing/routes.tsx
+++ b/frontend/src/routing/routes.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Archetypes from '../archetypes/Archetypes';
 import Data from '../data/Data';
+import ErrorBoundary from '../errors/ErrorBoundary';
 import Exploration from '../exploration/Exploration';
 import Home from '../home/Home';
 import Graph from '../visualization/Graph';
@@ -12,40 +13,68 @@ const routes: Record<string, RouteDefinition> = {
   Home: {
     path: '/home',
     label: 'Home',
-    content: () => <Home />,
+    content: () => (
+      <ErrorBoundary>
+        <Home />
+      </ErrorBoundary>
+    ),
   },
   Visualization: {
     path: '/visualization',
     label: 'Visualization',
     exact: true,
-    content: () => <Visualization />,
+    content: () => (
+      <ErrorBoundary>
+        <Visualization />
+      </ErrorBoundary>
+    ),
     tabs: [
       {
         path: '/visualization/graph',
         label: 'Graph',
-        content: () => <Graph />,
+        content: () => (
+          <ErrorBoundary>
+            <Graph />
+          </ErrorBoundary>
+        ),
       },
       {
         path: '/visualization/schema',
         label: 'Schema',
-        content: () => <Schema />,
+        content: () => (
+          <ErrorBoundary>
+            <Schema />
+          </ErrorBoundary>
+        ),
       },
     ],
   },
   Exploration: {
     path: '/exploration',
     label: 'Exploration',
-    content: () => <Exploration />,
+    content: () => (
+      <ErrorBoundary>
+        <Exploration />
+      </ErrorBoundary>
+    ),
   },
   Data: {
     path: '/data',
     label: 'Data',
-    content: () => <Data />,
+    content: () => (
+      <ErrorBoundary>
+        <Data />
+      </ErrorBoundary>
+    ),
   },
   Archetypes: {
     path: '/archetypes',
     label: 'Archetypes',
-    content: () => <Archetypes />,
+    content: () => (
+      <ErrorBoundary>
+        <Archetypes />
+      </ErrorBoundary>
+    ),
   },
 };
 


### PR DESCRIPTION
Closes #112. 
This PR adds an [Error Boundaries](https://reactjs.org/docs/error-boundaries.html).

Also wraps all routes in an Error Boundary. if you have different ideas of where to use them please let me know. The [documentation](https://reactjs.org/docs/error-boundaries.html#where-to-place-error-boundaries) says
>**Where to Place Error Boundaries**
The granularity of error boundaries is up to you. You may wrap top-level route components to display a “Something went wrong” message to the user, just like how server-side frameworks often handle crashes. You may also wrap individual widgets in an error boundary to protect them from crashing the rest of the application.

**Note for testing**: The create-react-app package has a tool called the [react-overlay-error](https://www.npmjs.com/package/react-error-overlay). This shows error messages from the console as an overlay over your app so you can easily check the stack trace and debug.

This won't show up in production mode, it's just a development tool duplicating the normal browser console.

You can hide this by pressing **Escape** to see the Error Component again.