### PR TITLE
Coloring

### DIFF
--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -31,7 +31,6 @@ export class AppService {
           ? []
           : await this.queryEdges(query?.limits?.edges),
     };
-
     return consolidateQueryResult(queryResult);
   }
 

--- a/backend/src/config/commonFunctions.ts
+++ b/backend/src/config/commonFunctions.ts
@@ -17,7 +17,7 @@ This file contains functions that are shared across the app
  *  query = `MATCH (a)-->(b) WHERE [...] RETURN ${neo4jReturnNodeDescriptor('b')}`; // cypher variables are called a and b
  */
 export function neo4jReturnNodeDescriptor(node: string): string {
-  return `ID(${node}) as id`;
+  return `ID(${node}) as id, labels(${node}) as types`;
 }
 
 /* istanbul ignore next */
@@ -41,7 +41,7 @@ export function neo4jReturnEdgeDescriptor(
   from: string,
   to: string
 ): string {
-  return `ID(${edge}) as id, ID(${from}) as from, ID(${to}) as to`;
+  return `ID(${edge}) as id, type(${edge}) as type, ID(${from}) as from, ID(${to}) as to`;
 }
 
 /* istanbul ignore next */

--- a/backend/src/filter/filter.service.ts
+++ b/backend/src/filter/filter.service.ts
@@ -87,7 +87,7 @@ export class FilterService implements FilterServiceBase {
       query = `${query} WHERE ${condition}`;
     }
 
-    query = `${query} ${neo4jReturnNodeDescriptor('n')}`;
+    query = `${query} RETURN ${neo4jReturnNodeDescriptor('n')}`;
 
     // Only add a LIMIT clause if a limit is specified.
     if (limit !== undefined) {
@@ -136,7 +136,7 @@ export class FilterService implements FilterServiceBase {
       query = `${query} WHERE ${condition}`;
     }
 
-    query = `${query} ${neo4jReturnEdgeDescriptor('e', 'from', 'to')}`;
+    query = `${query} RETURN ${neo4jReturnEdgeDescriptor('e', 'from', 'to')}`;
 
     // Only add a LIMIT clause if a limit is specified.
     if (limit !== undefined) {

--- a/backend/src/filter/filter.service.ts
+++ b/backend/src/filter/filter.service.ts
@@ -10,7 +10,10 @@ import {
   FilterModelEntry,
   NodeTypeFilterModel,
 } from '../shared/filter';
-import { neo4jReturnEdgeDescriptor, neo4jReturnNodeDescriptor } from '../config/commonFunctions';
+import {
+  neo4jReturnEdgeDescriptor,
+  neo4jReturnNodeDescriptor,
+} from '../config/commonFunctions';
 
 /**
  * The default implementation of the filter service for the neo4j database.

--- a/backend/src/filter/filter.service.ts
+++ b/backend/src/filter/filter.service.ts
@@ -10,6 +10,7 @@ import {
   FilterModelEntry,
   NodeTypeFilterModel,
 } from '../shared/filter';
+import { neo4jReturnEdgeDescriptor, neo4jReturnNodeDescriptor } from '../config/commonFunctions';
 
 /**
  * The default implementation of the filter service for the neo4j database.
@@ -83,7 +84,7 @@ export class FilterService implements FilterServiceBase {
       query = `${query} WHERE ${condition}`;
     }
 
-    query = `${query} RETURN ID(n) as id`;
+    query = `${query} ${neo4jReturnNodeDescriptor('n')}`;
 
     // Only add a LIMIT clause if a limit is specified.
     if (limit !== undefined) {
@@ -132,7 +133,7 @@ export class FilterService implements FilterServiceBase {
       query = `${query} WHERE ${condition}`;
     }
 
-    query = `${query} RETURN ID(e) as id, ID(from) as from, ID(to) as to`;
+    query = `${query} ${neo4jReturnEdgeDescriptor('e', 'from', 'to')}`;
 
     // Only add a LIMIT clause if a limit is specified.
     if (limit !== undefined) {

--- a/backend/src/utils/consolidateQueryResult.ts
+++ b/backend/src/utils/consolidateQueryResult.ts
@@ -60,6 +60,12 @@ export function consolidateQueryResult(
   const nodeIds = new Set<number>(
     dedupNodes.map((descriptor) => descriptor.id)
   );
+
+  const nodeMap = new Map();
+  for (const node of dedupNodes) {
+    nodeMap.set(node.id, node);
+  }
+
   const subsidiary: NodeResultDescriptor[] = [];
 
   for (let i = dedupEdges.length - 1; i >= 0; i -= 1) {
@@ -70,6 +76,7 @@ export function consolidateQueryResult(
         nodeIds.add(edge.from);
         subsidiary.push({
           id: edge.from,
+          types: nodeMap.get(edge.from).types,
           subsidiary: true,
         });
       }
@@ -78,6 +85,7 @@ export function consolidateQueryResult(
         nodeIds.add(edge.to);
         subsidiary.push({
           id: edge.to,
+          types: nodeMap.get(edge.to).types,
           subsidiary: true,
         });
       }

--- a/backend/src/utils/consolidateQueryResult.ts
+++ b/backend/src/utils/consolidateQueryResult.ts
@@ -61,11 +61,6 @@ export function consolidateQueryResult(
     dedupNodes.map((descriptor) => descriptor.id)
   );
 
-  const nodeMap = new Map();
-  for (const node of dedupNodes) {
-    nodeMap.set(node.id, node);
-  }
-
   const subsidiary: NodeResultDescriptor[] = [];
 
   for (let i = dedupEdges.length - 1; i >= 0; i -= 1) {
@@ -76,7 +71,7 @@ export function consolidateQueryResult(
         nodeIds.add(edge.from);
         subsidiary.push({
           id: edge.from,
-          types: nodeMap.get(edge.from).types,
+          types: [], // types of subsidiary nodes are unknown, color is yellow either way
           subsidiary: true,
         });
       }
@@ -85,7 +80,7 @@ export function consolidateQueryResult(
         nodeIds.add(edge.to);
         subsidiary.push({
           id: edge.to,
-          types: nodeMap.get(edge.to).types,
+          types: [], // types of subsidiary nodes are unknown, color is yellow either way
           subsidiary: true,
         });
       }

--- a/backend/tests/e2e/filter/filter.service.e2e.spec.ts
+++ b/backend/tests/e2e/filter/filter.service.e2e.spec.ts
@@ -58,8 +58,11 @@ describe('FilterService', () => {
       };
 
       const expectedQueryResult: QueryResult = {
-        nodes: [{ id: 0 }, { id: 3, subsidiary: true }],
-        edges: [{ id: 2, from: 3, to: 0 }],
+        nodes: [
+          { id: 0, types: ['Movie'] },
+          { id: 3, types: [], subsidiary: true },
+        ],
+        edges: [{ id: 2, type: 'DIRECTED', from: 3, to: 0 }],
       };
 
       // Act

--- a/backend/tests/fixtures/filter/FilterServicMock.ts
+++ b/backend/tests/fixtures/filter/FilterServicMock.ts
@@ -72,11 +72,12 @@ export default class FilterServiceMock implements FilterServiceBase {
       : edges;
 
     const result = {
-      nodes: filteredNodes.map((node) => ({ id: node.id })),
+      nodes: filteredNodes.map((node) => ({ id: node.id, types: node.types })),
       edges: filteredEdges.map((edge) => ({
         id: edge.id,
         from: edge.from,
         to: edge.to,
+        type: edge.type,
       })),
     };
     return Promise.resolve(consolidateQueryResult(result));

--- a/backend/tests/fixtures/testingDumpData.ts
+++ b/backend/tests/fixtures/testingDumpData.ts
@@ -13,7 +13,7 @@ export const queryAllDummies: {
   query: { limits: { nodes: 3, edges: 4 } },
   queryResult: {
     nodes: [
-      { id: 0, types: ['Person'] },
+      { id: 0, types: ['Movie'] },
       { id: 1, types: ['Person'] },
       { id: 2, types: ['Person'] },
     ],
@@ -29,7 +29,7 @@ export const queryAllNoLimitDummies: {
 } = {
   queryResult: {
     nodes: [
-      { id: 0, types: ['Person'] },
+      { id: 0, types: ['Movie'] },
       { id: 1, types: ['Person'] },
       { id: 2, types: ['Person'] },
       { id: 3, types: ['Person'] },
@@ -37,7 +37,7 @@ export const queryAllNoLimitDummies: {
     edges: [
       { id: 0, type: 'ACTED_IN', from: 1, to: 0 },
       { id: 1, type: 'ACTED_IN', from: 2, to: 0 },
-      { id: 2, type: 'ACTED_IN', from: 3, to: 0 },
+      { id: 2, type: 'DIRECTED', from: 3, to: 0 },
     ],
   },
 };

--- a/backend/tests/fixtures/testingDumpData.ts
+++ b/backend/tests/fixtures/testingDumpData.ts
@@ -12,10 +12,14 @@ export const queryAllDummies: {
 } = {
   query: { limits: { nodes: 3, edges: 4 } },
   queryResult: {
-    nodes: [{ id: 0 }, { id: 1 }, { id: 2 }],
+    nodes: [
+      { id: 0, types: ['Person'] },
+      { id: 1, types: ['Person'] },
+      { id: 2, types: ['Person'] },
+    ],
     edges: [
-      { id: 0, from: 1, to: 0 },
-      { id: 1, from: 2, to: 0 },
+      { id: 0, type: 'ACTED_IN', from: 1, to: 0 },
+      { id: 1, type: 'ACTED_IN', from: 2, to: 0 },
     ],
   },
 };
@@ -24,11 +28,16 @@ export const queryAllNoLimitDummies: {
   queryResult: QueryResult;
 } = {
   queryResult: {
-    nodes: [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }],
+    nodes: [
+      { id: 0, types: ['Person'] },
+      { id: 1, types: ['Person'] },
+      { id: 2, types: ['Person'] },
+      { id: 3, types: ['Person'] },
+    ],
     edges: [
-      { id: 0, from: 1, to: 0 },
-      { id: 1, from: 2, to: 0 },
-      { id: 2, from: 3, to: 0 },
+      { id: 0, type: 'ACTED_IN', from: 1, to: 0 },
+      { id: 1, type: 'ACTED_IN', from: 2, to: 0 },
+      { id: 2, type: 'ACTED_IN', from: 3, to: 0 },
     ],
   },
 };

--- a/backend/tests/unit/filter/filter.controller.spec.ts
+++ b/backend/tests/unit/filter/filter.controller.spec.ts
@@ -46,11 +46,16 @@ describe('FilterController', () => {
     it(`returns everything if no filter specified`, async () => {
       // Arrange
       const expected: QueryResult = {
-        nodes: [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }],
+        nodes: [
+          { id: 0, types: ['Movie'] },
+          { id: 1, types: ['Person'] },
+          { id: 2, types: ['Person'] },
+          { id: 3, types: ['Person'] },
+        ],
         edges: [
-          { id: 0, from: 1, to: 0 },
-          { id: 1, from: 2, to: 0 },
-          { id: 2, from: 3, to: 0 },
+          { id: 0, from: 1, to: 0, type: 'ACTED_IN' },
+          { id: 1, from: 2, to: 0, type: 'ACTED_IN' },
+          { id: 2, from: 3, to: 0, type: 'DIRECTED' },
         ],
       };
 
@@ -70,7 +75,7 @@ describe('FilterController', () => {
       };
 
       const expected: QueryResult = {
-        nodes: [{ id: 0 }],
+        nodes: [{ id: 0, types: ['Movie'] }],
         edges: [],
       };
 
@@ -91,8 +96,13 @@ describe('FilterController', () => {
       };
 
       const expected: QueryResult = {
-        nodes: [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }],
-        edges: [{ id: 2, from: 3, to: 0 }],
+        nodes: [
+          { id: 0, types: ['Movie'] },
+          { id: 1, types: ['Person'] },
+          { id: 2, types: ['Person'] },
+          { id: 3, types: ['Person'] },
+        ],
+        edges: [{ id: 2, from: 3, to: 0, type: 'DIRECTED' }],
       };
 
       // Act
@@ -112,7 +122,7 @@ describe('FilterController', () => {
       };
 
       const expected: QueryResult = {
-        nodes: [{ id: 1 }],
+        nodes: [{ id: 1, types: ['Person'] }],
         edges: [],
       };
 
@@ -139,7 +149,7 @@ describe('FilterController', () => {
       };
 
       const expected: QueryResult = {
-        nodes: [{ id: 1 }],
+        nodes: [{ id: 1, types: ['Person'] }],
         edges: [],
       };
 
@@ -163,7 +173,11 @@ describe('FilterController', () => {
       };
 
       const expected: QueryResult = {
-        nodes: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        nodes: [
+          { id: 1, types: ['Person'] },
+          { id: 2, types: ['Person'] },
+          { id: 3, types: ['Person'] },
+        ],
         edges: [],
       };
 
@@ -187,11 +201,16 @@ describe('FilterController', () => {
       };
 
       const expected: QueryResult = {
-        nodes: [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }],
+        nodes: [
+          { id: 0, types: ['Movie'] },
+          { id: 1, types: ['Person'] },
+          { id: 2, types: ['Person'] },
+          { id: 3, types: ['Person'] },
+        ],
         edges: [
-          { id: 0, from: 1, to: 0 },
-          { id: 1, from: 2, to: 0 },
-          { id: 2, from: 3, to: 0 },
+          { id: 0, type: 'ACTED_IN', from: 1, to: 0 },
+          { id: 1, type: 'ACTED_IN', from: 2, to: 0 },
+          { id: 2, type: 'DIRECTED', from: 3, to: 0 },
         ],
       };
 

--- a/backend/tests/unit/utils/consolidateQueryResult.spec.ts
+++ b/backend/tests/unit/utils/consolidateQueryResult.spec.ts
@@ -4,12 +4,19 @@ describe('consolidateQueryResult', () => {
   it('deduplicates nodes', async () => {
     // Arrange
     const queryResult = {
-      nodes: [{ id: 1 }, { id: 2 }, { id: 1 }],
+      nodes: [
+        { id: 1, types: ['Person'] },
+        { id: 2, types: ['Person'] },
+        { id: 1, types: ['Person'] },
+      ],
       edges: [],
     };
 
     const expectedQueryResult = {
-      nodes: [{ id: 1 }, { id: 2 }],
+      nodes: [
+        { id: 1, types: ['Person'] },
+        { id: 2, types: ['Person'] },
+      ],
       edges: [],
     };
 
@@ -23,19 +30,19 @@ describe('consolidateQueryResult', () => {
   it('deduplicates edges', async () => {
     // Arrange
     const queryResult = {
-      nodes: [{ id: 0 }],
+      nodes: [{ id: 0, types: ['Movie'] }],
       edges: [
-        { id: 1, from: 0, to: 0 },
-        { id: 2, from: 0, to: 0 },
-        { id: 1, from: 0, to: 0 },
+        { id: 1, type: 'ACTED_IN', from: 0, to: 0 },
+        { id: 2, type: 'ACTED_IN', from: 0, to: 0 },
+        { id: 1, type: 'ACTED_IN', from: 0, to: 0 },
       ],
     };
 
     const expectedQueryResult = {
-      nodes: [{ id: 0 }],
+      nodes: [{ id: 0, types: ['Movie'] }],
       edges: [
-        { id: 1, from: 0, to: 0 },
-        { id: 2, from: 0, to: 0 },
+        { id: 1, type: 'ACTED_IN', from: 0, to: 0 },
+        { id: 2, type: 'ACTED_IN', from: 0, to: 0 },
       ],
     };
 
@@ -49,16 +56,16 @@ describe('consolidateQueryResult', () => {
   it('removed edges that reference non included nodes', async () => {
     // Arrange
     const queryResult = {
-      nodes: [{ id: 0 }],
+      nodes: [{ id: 0, types: ['Movie'] }],
       edges: [
-        { id: 1, from: 0, to: 0 },
-        { id: 2, from: 0, to: 1 },
+        { id: 1, type: 'ACTED_IN', from: 0, to: 0 },
+        { id: 2, type: 'ACTED_IN', from: 0, to: 1 },
       ],
     };
 
     const expectedQueryResult = {
-      nodes: [{ id: 0 }],
-      edges: [{ id: 1, from: 0, to: 0 }],
+      nodes: [{ id: 0, types: ['Movie'] }],
+      edges: [{ id: 1, type: 'ACTED_IN', from: 0, to: 0 }],
     };
 
     // Act
@@ -71,18 +78,21 @@ describe('consolidateQueryResult', () => {
   it('adds subsidiary nodes that are non included but referenced by included edges', async () => {
     // Arrange
     const queryResult = {
-      nodes: [{ id: 0 }],
+      nodes: [{ id: 0, types: ['Movie'] }],
       edges: [
-        { id: 1, from: 0, to: 0 },
-        { id: 2, from: 0, to: 1 },
+        { id: 1, type: 'ACTED_IN', from: 0, to: 0 },
+        { id: 2, type: 'ACTED_IN', from: 0, to: 1 },
       ],
     };
 
     const expectedQueryResult = {
-      nodes: [{ id: 0 }, { id: 1, subsidiary: true }],
+      nodes: [
+        { id: 0, types: ['Movie'] },
+        { id: 1, types: [], subsidiary: true },
+      ],
       edges: [
-        { id: 1, from: 0, to: 0 },
-        { id: 2, from: 0, to: 1 },
+        { id: 1, type: 'ACTED_IN', from: 0, to: 0 },
+        { id: 2, type: 'ACTED_IN', from: 0, to: 1 },
       ],
     };
 

--- a/frontend/cypress/unit/stores/colors/EdgeColorStore.test.ts
+++ b/frontend/cypress/unit/stores/colors/EdgeColorStore.test.ts
@@ -1,0 +1,36 @@
+import EdgeColorStore from '../../../../src/stores/colors/EdgeColorStore';
+
+describe('EdgeColorStore', () => {
+  let edgeColorStore: EdgeColorStore;
+  const types = ['HELLO', 'WORLD', 'ANOTHER', 'KEY'];
+
+  beforeEach(() => {
+    edgeColorStore = new EdgeColorStore();
+  });
+
+  it('should return colors for types', () => {
+    const colorize = edgeColorStore.getValue();
+    const colors = types.map((t) => colorize(t));
+
+    for (const color of colors) {
+      expect(color.color).to.match(/#[0-9a-fA-F]{6}/);
+    }
+  });
+
+  it('should return new colors for new types', () => {
+    const colorize = edgeColorStore.getValue();
+    const colors = new Set(types.map((t) => colorize(t)));
+
+    expect(colors.size).to.be.eq(types.length);
+  });
+
+  it('should return the same color for the same type', () => {
+    const colorize = edgeColorStore.getValue();
+    const numCalls = 5;
+
+    const colors = new Array(numCalls).map(() => colorize('MyType'));
+
+    expect(colors).to.have.length(numCalls);
+    expect(new Set(colors).size).to.be.eq(1);
+  });
+});

--- a/frontend/cypress/unit/stores/colors/NodeColorStore.test.ts
+++ b/frontend/cypress/unit/stores/colors/NodeColorStore.test.ts
@@ -1,0 +1,44 @@
+import NodeColorStore from '../../../../src/stores/colors/NodeColorStore';
+
+describe('NodeColorStore', () => {
+  let nodeColorStore: NodeColorStore;
+  const types = [['HELLO'], ['WORLD'], ['COMPOSED', 'KEY']];
+
+  beforeEach(() => {
+    nodeColorStore = new NodeColorStore();
+  });
+
+  it('should return colors for types', () => {
+    const colorize = nodeColorStore.getValue();
+    const colors = types.map((t) => colorize(t));
+
+    for (const color of colors) {
+      expect(color.color).to.match(/#[0-9a-fA-F]{6}/);
+    }
+  });
+
+  it('should return new colors for new types', () => {
+    const colorize = nodeColorStore.getValue();
+    const colors = new Set(types.map((t) => colorize(t)));
+
+    expect(colors.size).to.be.eq(types.length);
+  });
+
+  it('should return the same color for the same type', () => {
+    const colorize = nodeColorStore.getValue();
+    const numCalls = 5;
+
+    const colors = new Array(numCalls).map(() => colorize(['MyType']));
+
+    expect(colors).to.have.length(numCalls);
+    expect(new Set(colors).size).to.be.eq(1);
+  });
+
+  it('should return the same color independent of the type order', () => {
+    const colorize = nodeColorStore.getValue();
+    const color1 = colorize(['HELLO', 'WORLD']);
+    const color2 = colorize(['WORLD', 'HELLO']);
+
+    expect(color1).to.deep.eq(color2);
+  });
+});

--- a/frontend/src/services/query/QueryServiceImpl.ts
+++ b/frontend/src/services/query/QueryServiceImpl.ts
@@ -16,7 +16,7 @@ const MAX_BATCH_SIZE = 90;
 
 // TODO: This is currently not in use, so untested, add tests when this is needed in production code.
 /* istanbul ignore next */
-function createBatches(array: number[] | NodeDescriptor[]) {
+function createBatches(array: number[] | NodeDescriptor[] | EdgeDescriptor[]) {
   const batches = [];
   for (let i = 0; i < array.length; i += MAX_BATCH_SIZE) {
     batches.push(array.slice(i, i + MAX_BATCH_SIZE));

--- a/frontend/src/stores/colors/BaseEntityColorStore.ts
+++ b/frontend/src/stores/colors/BaseEntityColorStore.ts
@@ -1,0 +1,60 @@
+/* istanbul ignore file */
+
+import 'reflect-metadata';
+import { injectable } from 'inversify';
+import { BehaviorSubject, Observable } from 'rxjs';
+import EntityVisualisationAttributes from './EntityVisualisationAttributes';
+import getNthColor from './getNthColor';
+
+type EntityConverter<T> = (type: T) => EntityVisualisationAttributes;
+
+/**
+ * A simple store contains a single state.
+ * The current state can be retrieved with {@link getValue} (just once)
+ * and with {@link getState} (until unsubscribed).
+ */
+@injectable()
+export default abstract class BaseEntityColorStore<EntityTypeId> {
+  protected readonly entityTypeColorMap = new Map<string, string>();
+
+  /**
+   * Contains the state.
+   * Returns the current state immediately after subscribing.
+   * @protected
+   */
+  protected readonly storeSubject = new BehaviorSubject<
+    EntityConverter<EntityTypeId>
+  >(this.getInitialValue());
+
+  /**
+   * Returns the initial value of the stored subject.
+   * @protected
+   */
+  protected getInitialValue(): EntityConverter<EntityTypeId> {
+    return (entity) => {
+      const type = this.getTypeOfEntity(entity);
+      let color = this.entityTypeColorMap.get(type);
+      if (!color) {
+        color = getNthColor(this.entityTypeColorMap.size);
+        this.entityTypeColorMap.set(type, color);
+      }
+      return { color };
+    };
+  }
+
+  protected abstract getTypeOfEntity(entityTypeId: EntityTypeId): string;
+
+  /**
+   * Returns an observable that outputs the stored value.
+   */
+  public getState(): Observable<EntityConverter<EntityTypeId>> {
+    return this.storeSubject.pipe();
+  }
+
+  /**
+   * Returns the current value of the stored value.
+   */
+  public getValue(): EntityConverter<EntityTypeId> {
+    return this.storeSubject.value;
+  }
+}

--- a/frontend/src/stores/colors/EdgeColorStore.ts
+++ b/frontend/src/stores/colors/EdgeColorStore.ts
@@ -1,15 +1,10 @@
-import { purple } from '@material-ui/core/colors';
 import { Edge } from '../../shared/entities';
-import SimpleStore from '../SimpleStore';
-import EntityVisualisationAttributes from './EntityVisualisationAttributes';
+import BaseEntityColorStore from './BaseEntityColorStore';
 
 type EdgeType = Edge['type'];
 
-type StoreType = (type: EdgeType) => EntityVisualisationAttributes;
-
-export default class EdgeColorStore extends SimpleStore<StoreType> {
-  protected getInitialValue(): StoreType {
-    // TODO real implementation
-    return () => ({ color: purple[500] });
+export default class EdgeColorStore extends BaseEntityColorStore<EdgeType> {
+  protected getTypeOfEntity(entityTypeId: EdgeType): string {
+    return entityTypeId;
   }
 }

--- a/frontend/src/stores/colors/NodeColorStore.ts
+++ b/frontend/src/stores/colors/NodeColorStore.ts
@@ -1,15 +1,10 @@
-import { green } from '@material-ui/core/colors';
 import { Node } from '../../shared/entities';
-import SimpleStore from '../SimpleStore';
-import EntityVisualisationAttributes from './EntityVisualisationAttributes';
+import BaseEntityColorStore from './BaseEntityColorStore';
 
 type NodeTypes = Node['types'];
 
-type StoreType = (type: NodeTypes) => EntityVisualisationAttributes;
-
-export default class NodeColorStore extends SimpleStore<StoreType> {
-  protected getInitialValue(): StoreType {
-    // TODO real implementation
-    return () => ({ color: green[500] });
+export default class NodeColorStore extends BaseEntityColorStore<NodeTypes> {
+  protected getTypeOfEntity(entityTypeId: NodeTypes): string {
+    return entityTypeId.sort((a, b) => a.localeCompare(b)).join(' ');
   }
 }

--- a/frontend/src/visualization/shared-ops/convertQueryResult.ts
+++ b/frontend/src/visualization/shared-ops/convertQueryResult.ts
@@ -31,7 +31,7 @@ function convertEdge(edge: EdgeDescriptor): vis.Edge {
     id: edge.id,
     from: edge.from,
     to: edge.to,
-    color: colorize(type).toString(),
+    color: colorize(type).color,
   };
 }
 

--- a/frontend/src/visualization/shared-ops/convertQueryResult.ts
+++ b/frontend/src/visualization/shared-ops/convertQueryResult.ts
@@ -2,12 +2,16 @@ import { GraphData } from 'react-graph-vis';
 import * as vis from 'vis-network';
 import { EdgeDescriptor } from '../../shared/entities';
 import { NodeResultDescriptor, QueryResult } from '../../shared/queries';
+import NodeColorStore from '../../stores/colors/NodeColorStore';
+
+const nodeColorStore = new NodeColorStore();
+const colorize = nodeColorStore.getValue();
 
 function convertNode(node: NodeResultDescriptor): vis.Node {
   const result: vis.Node = {
     id: node.id,
     label: node.id.toString(),
-    // Advanced stuff, like styling nodes with different types differently...
+    color: colorize(node.types).toString(),
   };
 
   if (node.subsidiary) {
@@ -22,11 +26,12 @@ function convertNodes(nodes: NodeResultDescriptor[]): vis.Node[] {
 }
 
 function convertEdge(edge: EdgeDescriptor): vis.Edge {
+  const type = [edge.type];
   return {
     id: edge.id,
     from: edge.from,
     to: edge.to,
-    // Advanced stuff, like styling edges with different types differently...
+    color: colorize(type).toString(),
   };
 }
 

--- a/frontend/src/visualization/shared-ops/convertQueryResult.ts
+++ b/frontend/src/visualization/shared-ops/convertQueryResult.ts
@@ -11,7 +11,7 @@ function convertNode(node: NodeResultDescriptor): vis.Node {
   const result: vis.Node = {
     id: node.id,
     label: node.id.toString(),
-    color: colorize(node.types).toString(),
+    color: colorize(node.types).color,
   };
 
   if (node.subsidiary) {

--- a/frontend/src/visualization/shared-ops/convertQueryResult.ts
+++ b/frontend/src/visualization/shared-ops/convertQueryResult.ts
@@ -11,7 +11,7 @@ function convertNode(node: NodeResultDescriptor): vis.Node {
   const result: vis.Node = {
     id: node.id,
     label: node.id.toString(),
-    color: colorize(node.types).color,
+    color: colorize({ id: node.id, types: node.types }).color,
   };
 
   if (node.subsidiary) {
@@ -31,7 +31,7 @@ function convertEdge(edge: EdgeDescriptor): vis.Edge {
     id: edge.id,
     from: edge.from,
     to: edge.to,
-    color: colorize(type).color,
+    color: colorize({ id: edge.id, types: type }).color,
   };
 }
 

--- a/shared/src/entities/EdgeDescriptor.ts
+++ b/shared/src/entities/EdgeDescriptor.ts
@@ -3,6 +3,7 @@
  */
 export interface EdgeDescriptor {
   id: number;
+  type: string;
   /**
    * ID of the start node
    */

--- a/shared/src/entities/NodeDescriptor.ts
+++ b/shared/src/entities/NodeDescriptor.ts
@@ -3,4 +3,5 @@
  */
 export interface NodeDescriptor {
   id: number;
+  types: string[];
 }


### PR DESCRIPTION
Help: Why do the nodes still have no `types` property after adjusting the `neo4jReturnEdgeDescriptor` method in **backend/src/config/commonFunctions.ts** ?

I need to access the Node and Edge Types in **frontend/src/visualization/shared-ops/converQueryResult.ts**, in order to colorize the entities based on their type.
