### PR TITLE
Color stores to accept entity descriptors as arguments

### DIFF
--- a/frontend/cypress/unit/stores/colors/EdgeColorStore.test.ts
+++ b/frontend/cypress/unit/stores/colors/EdgeColorStore.test.ts
@@ -1,8 +1,14 @@
 import EdgeColorStore from '../../../../src/stores/colors/EdgeColorStore';
+import { EdgeDescriptor } from '../../../../src/shared/entities';
 
 describe('EdgeColorStore', () => {
   let edgeColorStore: EdgeColorStore;
-  const types = ['HELLO', 'WORLD', 'ANOTHER', 'KEY'];
+  const dummies: EdgeDescriptor[] = [
+    { id: 1, type: 'HELLO', from: 1, to: 1 },
+    { id: 2, type: 'WORLD', from: 2, to: 2 },
+    { id: 3, type: 'ANOTHER', from: 3, to: 3 },
+    { id: 4, type: 'KEY', from: 4, to: 4 },
+  ];
 
   beforeEach(() => {
     edgeColorStore = new EdgeColorStore();
@@ -10,7 +16,7 @@ describe('EdgeColorStore', () => {
 
   it('should return colors for types', () => {
     const colorize = edgeColorStore.getValue();
-    const colors = types.map((t) => colorize(t));
+    const colors = dummies.map((t) => colorize(t));
 
     for (const color of colors) {
       expect(color.color).to.match(/#[0-9a-fA-F]{6}/);
@@ -19,16 +25,16 @@ describe('EdgeColorStore', () => {
 
   it('should return new colors for new types', () => {
     const colorize = edgeColorStore.getValue();
-    const colors = new Set(types.map((t) => colorize(t)));
+    const colors = new Set(dummies.map((t) => colorize(t)));
 
-    expect(colors.size).to.be.eq(types.length);
+    expect(colors.size).to.be.eq(dummies.length);
   });
 
   it('should return the same color for the same type', () => {
     const colorize = edgeColorStore.getValue();
     const numCalls = 5;
 
-    const colors = new Array(numCalls).map(() => colorize('MyType'));
+    const colors = new Array(numCalls).map(() => colorize(dummies[0]));
 
     expect(colors).to.have.length(numCalls);
     expect(new Set(colors).size).to.be.eq(1);

--- a/frontend/cypress/unit/stores/colors/NodeColorStore.test.ts
+++ b/frontend/cypress/unit/stores/colors/NodeColorStore.test.ts
@@ -1,8 +1,13 @@
 import NodeColorStore from '../../../../src/stores/colors/NodeColorStore';
+import { NodeDescriptor } from '../../../../src/shared/entities';
 
 describe('NodeColorStore', () => {
   let nodeColorStore: NodeColorStore;
-  const types = [['HELLO'], ['WORLD'], ['COMPOSED', 'KEY']];
+  const dummies: NodeDescriptor[] = [
+    { id: 1, types: ['HELLO'] },
+    { id: 2, types: ['WORLD'] },
+    { id: 3, types: ['COMPOSED', 'KEY'] },
+  ];
 
   beforeEach(() => {
     nodeColorStore = new NodeColorStore();
@@ -10,7 +15,7 @@ describe('NodeColorStore', () => {
 
   it('should return colors for types', () => {
     const colorize = nodeColorStore.getValue();
-    const colors = types.map((t) => colorize(t));
+    const colors = dummies.map((t) => colorize(t));
 
     for (const color of colors) {
       expect(color.color).to.match(/#[0-9a-fA-F]{6}/);
@@ -19,16 +24,16 @@ describe('NodeColorStore', () => {
 
   it('should return new colors for new types', () => {
     const colorize = nodeColorStore.getValue();
-    const colors = new Set(types.map((t) => colorize(t)));
+    const colors = new Set(dummies.map((t) => colorize(t)));
 
-    expect(colors.size).to.be.eq(types.length);
+    expect(colors.size).to.be.eq(dummies.length);
   });
 
   it('should return the same color for the same type', () => {
     const colorize = nodeColorStore.getValue();
     const numCalls = 5;
 
-    const colors = new Array(numCalls).map(() => colorize(['MyType']));
+    const colors = new Array(numCalls).map(() => colorize(dummies[0]));
 
     expect(colors).to.have.length(numCalls);
     expect(new Set(colors).size).to.be.eq(1);
@@ -36,8 +41,8 @@ describe('NodeColorStore', () => {
 
   it('should return the same color independent of the type order', () => {
     const colorize = nodeColorStore.getValue();
-    const color1 = colorize(['HELLO', 'WORLD']);
-    const color2 = colorize(['WORLD', 'HELLO']);
+    const color1 = colorize({ id: 1, types: ['HELLO', 'WORLD'] });
+    const color2 = colorize({ id: 2, types: ['WORLD', 'HELLO'] });
 
     expect(color1).to.deep.eq(color2);
   });
@@ -45,12 +50,12 @@ describe('NodeColorStore', () => {
   it('should not alter the input array', () => {
     const colorize = nodeColorStore.getValue();
 
-    const arr1 = ['A', 'B'];
-    colorize(arr1);
-    expect(arr1).to.have.ordered.members(['A', 'B']);
+    const dummy1: NodeDescriptor = { id: 1, types: ['A', 'B'] };
+    colorize(dummy1);
+    expect(dummy1.types).to.have.ordered.members(['A', 'B']);
 
-    const arr2 = ['D', 'C'];
-    colorize(arr2);
-    expect(arr2).to.have.ordered.members(['D', 'C']);
+    const dummy2: NodeDescriptor = { id: 1, types: ['D', 'C'] };
+    colorize(dummy2);
+    expect(dummy2.types).to.have.ordered.members(['D', 'C']);
   });
 });

--- a/frontend/src/stores/colors/BaseEntityColorStore.ts
+++ b/frontend/src/stores/colors/BaseEntityColorStore.ts
@@ -5,6 +5,7 @@ import { injectable } from 'inversify';
 import { BehaviorSubject, Observable } from 'rxjs';
 import EntityVisualisationAttributes from './EntityVisualisationAttributes';
 import getNthColor from './getNthColor';
+import { EdgeDescriptor, NodeDescriptor } from '../../shared/entities';
 
 type EntityConverter<T> = (type: T) => EntityVisualisationAttributes;
 
@@ -14,7 +15,9 @@ type EntityConverter<T> = (type: T) => EntityVisualisationAttributes;
  * and with {@link getState} (until unsubscribed).
  */
 @injectable()
-export default abstract class BaseEntityColorStore<EntityTypeId> {
+export default abstract class BaseEntityColorStore<
+  EntityTypeId extends EdgeDescriptor | NodeDescriptor
+> {
   protected readonly entityTypeColorMap = new Map<string, string>();
 
   /**

--- a/frontend/src/stores/colors/EdgeColorStore.ts
+++ b/frontend/src/stores/colors/EdgeColorStore.ts
@@ -1,10 +1,8 @@
-import { Edge } from '../../shared/entities';
+import { EdgeDescriptor } from '../../shared/entities';
 import BaseEntityColorStore from './BaseEntityColorStore';
 
-type EdgeType = Edge['type'];
-
-export default class EdgeColorStore extends BaseEntityColorStore<EdgeType> {
-  protected getTypeOfEntity(entityTypeId: EdgeType): string {
-    return entityTypeId;
+export default class EdgeColorStore extends BaseEntityColorStore<EdgeDescriptor> {
+  protected getTypeOfEntity(edgeDescriptor: EdgeDescriptor): string {
+    return edgeDescriptor.type;
   }
 }

--- a/frontend/src/stores/colors/NodeColorStore.ts
+++ b/frontend/src/stores/colors/NodeColorStore.ts
@@ -1,11 +1,9 @@
-import { Node } from '../../shared/entities';
+import { NodeDescriptor } from '../../shared/entities';
 import BaseEntityColorStore from './BaseEntityColorStore';
 
-type NodeTypes = Node['types'];
-
-export default class NodeColorStore extends BaseEntityColorStore<NodeTypes> {
-  protected getTypeOfEntity(entityTypeId: NodeTypes): string {
-    return entityTypeId
+export default class NodeColorStore extends BaseEntityColorStore<NodeDescriptor> {
+  protected getTypeOfEntity(nodeDescriptor: NodeDescriptor): string {
+    return nodeDescriptor.types
       .map((x) => x)
       .sort((a, b) => a.localeCompare(b))
       .join(' ');


### PR DESCRIPTION
Use entity descriptors over type string or types array to make it more future proof.

Tests will fail since it uses changes from #254 