### PR TITLE
swap order chord diagram page

### DIFF
--- a/frontend/src/visualization/pages/ChordDetails.tsx
+++ b/frontend/src/visualization/pages/ChordDetails.tsx
@@ -12,11 +12,11 @@ import {
   TableCell,
   TableRow,
 } from '@material-ui/core';
-import useObservable from '../utils/useObservable';
-import useService from '../dependency-injection/useService';
-import NodeTypeComponent from '../search/helper/NodeTypeComponent';
-import ChordDetailsStateStore from '../stores/details/ChordDetailsStateStore';
-import EntityStyleStore from '../stores/colors/EntityStyleStore';
+import useObservable from '../../utils/useObservable';
+import useService from '../../dependency-injection/useService';
+import NodeTypeComponent from '../../search/helper/NodeTypeComponent';
+import ChordDetailsStateStore from '../../stores/details/ChordDetailsStateStore';
+import EntityStyleStore from '../../stores/colors/EntityStyleStore';
 
 const useStyles = makeStyles({
   root: {

--- a/frontend/src/visualization/pages/ChordPage.tsx
+++ b/frontend/src/visualization/pages/ChordPage.tsx
@@ -10,7 +10,7 @@ import { SchemaService } from '../../services/schema';
 import { NodeTypeConnectionInfo } from '../../shared/schema';
 import useObservable from '../../utils/useObservable';
 import { EntityStyleProvider } from '../../stores/colors';
-import ChordDetails from '../ChordDetails';
+import ChordDetails from './ChordDetails';
 import ChordDetailsStateStore from '../../stores/details/ChordDetailsStateStore';
 import SearchSelectionStore from '../../stores/SearchSelectionStore';
 import EntityStyleStore from '../../stores/colors/EntityStyleStore';
@@ -143,7 +143,10 @@ export default function ChordPage(): JSX.Element {
     <Box p={3}>
       <h1>Chord Diagram</h1>
       <Container maxWidth={false}>
-        <Grid container spacing={0} justify="space-between">
+        <Grid container spacing={0}>
+          <Grid item lg={5} md={12}>
+            <ChordDetails />
+          </Grid>
           <Grid item lg={5} md={12}>
             <ChordDiagram
               blurOnHover
@@ -159,9 +162,6 @@ export default function ChordPage(): JSX.Element {
               }}
               outerRadius={260} // workaround for labels being cut off
             />
-          </Grid>
-          <Grid item lg={5} md={12}>
-            <ChordDetails />
           </Grid>
         </Grid>
       </Container>


### PR DESCRIPTION
From #344
> Split subpage in two containers:
> - Right side: Chord diagram
> - When clicked on: on leftside display numbers of edges to respective nodes

It was the other way around